### PR TITLE
Evan help request controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,78 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "HelpRequest")
+@RequestMapping("/api/HelpRequest")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+    
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @Operation(summary= "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        Iterable<HelpRequest> requests = helpRequestRepository.findAll();
+        return requests;
+    }
+
+    @Operation(summary= "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="teamId") @RequestParam String teamId,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="requestTime") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name="explination") @RequestParam String explination,
+            @Parameter(name="solved") @RequestParam boolean solved
+            )
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplination(explination);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -50,7 +50,7 @@ public class UCSBDatesController extends ApiController {
     public UCSBDate postUCSBDate(
             @Parameter(name="quarterYYYYQ") @RequestParam String quarterYYYYQ,
             @Parameter(name="name") @RequestParam String name,
-            @Parameter(name="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            @Parameter(name="localDateTime") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explination;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,80 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "HelpRequest-1",
+      "author": "evanja",
+      "preConditions": [
+        {
+          "onFail": "MARK_RAN"
+        },
+        {
+          "not": [
+            {
+              "tableExists": {
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      ],
+      "changes": [
+        {
+          "createTable": {
+            "columns": [
+              {
+                "column": {
+                  "autoIncrement": true,
+                  "constraints": {
+                    "primaryKey": true,
+                    "primaryKeyName": "CONSTRAINT_45138"
+                  },
+                  "name": "ID",
+                  "type": "BIGINT"
+                }
+              },
+              {
+                "column": {
+                  "name": "EXPLINATION",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "REQUEST_TIME",
+                  "type": "TIMESTAMP"
+                }
+              },
+              {
+                "column": {
+                  "name": "REQUESTER_EMAIL",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "constraints": {
+                    "nullable": false
+                  },
+                  "name": "SOLVED",
+                  "type": "BOOLEAN"
+                }
+              },
+              {
+                "column": {
+                  "name": "TABLE_OR_BREAKOUT_ROOM",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "TEAM_ID",
+                  "type": "VARCHAR(255)"
+                }
+              }]
+            ,
+            "tableName": "HELPREQUESTS"
+          }
+        }]
+    }
+  }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,151 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.hibernate.boot.model.source.internal.hbm.Helper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+    
+    @MockBean
+    HelpRequestRepository helpRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/helprequest/all
+    
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/HelpRequest/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/HelpRequest/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_help_requests() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            HelpRequest helpRequest1 = HelpRequest.builder()
+                            .requesterEmail("evanja57@gmail.com")
+                            .teamId("s24-4pm-2")
+                            .tableOrBreakoutRoom("2")
+                            .requestTime(ldt1)
+                            .explination("can't log in")
+                            .solved(false)
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            HelpRequest helpRequest2 = HelpRequest.builder()
+                            .requesterEmail("easakawa@ucsb.edu")
+                            .teamId("s24-5pm-3")
+                            .tableOrBreakoutRoom("5")
+                            .requestTime(ldt2)
+                            .explination("lost computer")
+                            .solved(true)
+                            .build();
+
+            ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>();
+            expectedHelpRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+            when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/HelpRequest/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(helpRequestRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/HelpRequest/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/HelpRequest/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/HelpRequest/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_help_request() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            HelpRequest helpRequest1 = HelpRequest.builder()
+                            .requesterEmail("evanja57@gmail.com")
+                            .teamId("s24-4pm-2")
+                            .tableOrBreakoutRoom("2")
+                            .requestTime(ldt1)
+                            .explination("lost")
+                            .solved(true)
+                            .build();
+
+            when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/HelpRequest/post?requesterEmail=evanja57@gmail.com&teamId=s24-4pm-2&tableOrBreakoutRoom=2&requestTime=2022-01-03T00:00:00&explination=lost&solved=true")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(helpRequestRepository, times(1)).save(helpRequest1);
+            String expectedJson = mapper.writeValueAsString(helpRequest1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
In this PR, I have created a controller for the HelpRequest api which allows for both POST's and GET all requests. I have verified that this passes 100% jacoco line coverage, and kills 100% of mutations (but the mutation test gives 98% line coverage). I have also verified on my [dev deployment](https://team02-evanja57-dev.dokku-02.cs.ucsb.edu/) that when I am logged in, HelpRequest suppports both GET and POST.

Closes #33 